### PR TITLE
Various improvements, added options

### DIFF
--- a/ansiblespec_runner.rb
+++ b/ansiblespec_runner.rb
@@ -12,6 +12,7 @@ config = {}
 config[:color] = false
 config[:format] = "documentation"
 config[:default_path] = ""
+config[:ansible_path] = ""
 config[:rspec_path] = ""
 config[:require] = false
 config[:vault_password_file] = ""
@@ -24,6 +25,7 @@ ARGV.options do |opts|
   opts.on("-c", "--color")              { config[:color] = true }
   opts.on("-f", "--format FORMATTER", String) { |val| config[:format] = val }
   opts.on("", "--default-path PATH", String) { |val| config[:default_path] = val } 
+  opts.on("", "--ansible-path PATH", String) { |val| config[:ansible_path] = val }
   opts.on("-v", "--version")              { version = true }
   opts.on("", "--rspec-path PATH", String) { |val| config[:rspec_path] = "#{val}/" }
   opts.on("", "--require REQUIRE", String) { |val| config[:require] = val }
@@ -68,13 +70,18 @@ playbook_file = YAML.load_file("#{kitchen_path}/#{playbook}")
 properties = {}
 keys = 0
 
+ansible_bin = "ansible"
+if config[:ansible_path] != ""
+  ansible_bin = "#{config[:ansible_path]}/ansible"
+end
+
 playbook_file.each do |item|
   ansible_hosts = item['hosts'].split(',')
   ansible_roles = item['roles']
   hostnames = false
   ansible_hosts.each do |h|
     begin
-      cmd = "ansible #{h} --list-hosts -i #{kitchen_path}/#{inventoryfile}"
+      cmd = "#{ansible_bin} #{h} --list-hosts -i #{kitchen_path}/#{inventoryfile}"
       if config[:vault_password_file] != ""
         cmd += " --vault-password-file #{config[:vault_password_file]}"
       end

--- a/ansiblespec_runner.rb
+++ b/ansiblespec_runner.rb
@@ -87,7 +87,6 @@ playbook_file.each do |item|
           puts "group: #{h} host: #{line.strip!} roles: #{ansible_roles}"
           hostnames = true
       end
-    rescue
     end
     if !hostnames
       keys += 1

--- a/ansiblespec_runner.rb
+++ b/ansiblespec_runner.rb
@@ -79,6 +79,9 @@ playbook_file.each do |item|
         cmd += " --vault-password-file #{config[:vault_password_file]}"
       end
       `#{cmd}`.lines do |line|
+          if /hosts \(\d+\):/.match(line)
+            next
+          end
           keys += 1
           properties["host_#{keys}"] = {:host => line.strip, :roles => ansible_roles}
           puts "group: #{h} host: #{line.strip!} roles: #{ansible_roles}"


### PR DESCRIPTION
I noticed when setting up ansible spec for https://github.com/HBOCodeLabs/SRE-Prometheus that `kitchen verify` was running serverspec twice when there was only one host. I dug into various files and found that this runner had some flaws.

1. 0e13eb1 fixes the duplicates issue. Apparently ansible has been adding a hosts(#) line in the output of `--list-hosts` for some time https://github.com/ansible/ansible/blob/15a04a3da7b268e35e1d2688f86d084047e746f1/lib/ansible/cli/adhoc.py#L125-L126. This runner was picking that line up as a unique host and trying to treat it as such.

2. I added a flag for specifing the location of a ansible vault password file. We are able to specify a file for the ansible provisioner but we also need to specify it for the verifier, since `--list-hosts` requires decrypting encrypted vars.

3. #2 was not noticed in https://github.com/HBOCodeLabs/SRE-Grafana because of the `rescue` removed here b891ca8. This was causing a silent failure and in the case of Grafana defaulting to one localhost.

4. I also added an `--ansible-path` option because of another issue noticed in the Grafana repo. Prometheus was doing fine because it could find `/usr/local/bin/ansible` as the ubuntu root user. Grafana uses Amazon Linux and the root user has a different path that does not include `/usr/local/bin`. I think these lines https://github.com/neillturner/kitchen-verifier-serverspec/blob/master/lib/kitchen/verifier/serverspec.rb#L289-L290 result in the ansible spec runner always running as root. Rather than modify the root PATH I felt it follows the verifier config style to provide an option to specify the path where `ansible` can be found.